### PR TITLE
Overloaded some operators to use with Expression instances

### DIFF
--- a/Adam.JSGenerator.Tests/BinaryOperationExpressionTests.cs
+++ b/Adam.JSGenerator.Tests/BinaryOperationExpressionTests.cs
@@ -29,7 +29,9 @@ namespace Adam.JSGenerator.Tests
         public void BinaryOperationExpressionSupportsAdd()
         {
             var b = A.AddWith(B);
+            Assert.AreEqual("a+b;", b.ToString());
 
+            b = A + B;
             Assert.AreEqual("a+b;", b.ToString());
         }
 
@@ -37,7 +39,9 @@ namespace Adam.JSGenerator.Tests
         public void BinaryOperationExpressionSupportsAddAndAssign()
         {
             var b = A.AddWith(B).AndAssign();
+            Assert.AreEqual("a+=b;", b.ToString());
 
+            b = (A + B).AndAssign();
             Assert.AreEqual("a+=b;", b.ToString());
         }
 
@@ -45,7 +49,9 @@ namespace Adam.JSGenerator.Tests
         public void BinaryOperationExpressionSupportsSubtract()
         {
             var b = A.SubtractWith(B);
+            Assert.AreEqual("a-b;", b.ToString());
 
+            b = A - B;
             Assert.AreEqual("a-b;", b.ToString());
         }
 
@@ -53,7 +59,9 @@ namespace Adam.JSGenerator.Tests
         public void BinaryOperationExpressionSupportsSubtractAndAssign()
         {
             var b = A.SubtractWith(B).AndAssign();
+            Assert.AreEqual("a-=b;", b.ToString());
 
+            b = (A - B).AndAssign();
             Assert.AreEqual("a-=b;", b.ToString());
         }
 
@@ -61,7 +69,9 @@ namespace Adam.JSGenerator.Tests
         public void BinaryOperationExpressionSupportsMultiply()
         {
             var b = A.MultiplyBy(B);
+            Assert.AreEqual("a*b;", b.ToString());
 
+            b = A*B;
             Assert.AreEqual("a*b;", b.ToString());
         }
 
@@ -69,7 +79,9 @@ namespace Adam.JSGenerator.Tests
         public void BinaryOperationExpressionSupportsMultiplyAndAssign()
         {
             var b = A.MultiplyBy(B).AndAssign();
+            Assert.AreEqual("a*=b;", b.ToString());
 
+            b = (A*B).AndAssign();
             Assert.AreEqual("a*=b;", b.ToString());
         }
 
@@ -77,7 +89,9 @@ namespace Adam.JSGenerator.Tests
         public void BinaryOperationExpressionSupportsDivide()
         {
             var b = A.DivideBy(B);
+            Assert.AreEqual("a/b;", b.ToString());
 
+            b = A/B;
             Assert.AreEqual("a/b;", b.ToString());
         }
 
@@ -85,7 +99,9 @@ namespace Adam.JSGenerator.Tests
         public void BinaryOperationExpressionSupportsDivideAndAssign()
         {
             var b = A.DivideBy(B).AndAssign();
+            Assert.AreEqual("a/=b;", b.ToString());
 
+            b = (A/B).AndAssign();
             Assert.AreEqual("a/=b;", b.ToString());
         }
 
@@ -93,7 +109,9 @@ namespace Adam.JSGenerator.Tests
         public void BinaryOperationExpressionSupportsRemain()
         {
             var b = A.RemainderBy(B);
+            Assert.AreEqual("a%b;", b.ToString());
 
+            b = A%B;
             Assert.AreEqual("a%b;", b.ToString());
         }
 
@@ -101,7 +119,9 @@ namespace Adam.JSGenerator.Tests
         public void BinaryOperationExpressionSupportsRemainAndAssign()
         {
             var b = A.RemainderBy(B).AndAssign();
+            Assert.AreEqual("a%=b;", b.ToString());
 
+            b = (A%B).AndAssign();
             Assert.AreEqual("a%=b;", b.ToString());
         }
 
@@ -109,7 +129,9 @@ namespace Adam.JSGenerator.Tests
         public void BinaryOperationExpressionSupportsBitwiseAnd()
         {
             var b = A.BitwiseAndWith(B);
+            Assert.AreEqual("a&b;", b.ToString());
 
+            b = A & B;
             Assert.AreEqual("a&b;", b.ToString());
         }
 
@@ -117,7 +139,9 @@ namespace Adam.JSGenerator.Tests
         public void BinaryOperationExpressionSupportsBitwiseAndAndAssign()
         {
             var b = A.BitwiseAndWith(B).AndAssign();
+            Assert.AreEqual("a&=b;", b.ToString());
 
+            b = (A & B).AndAssign();
             Assert.AreEqual("a&=b;", b.ToString());
         }
 
@@ -125,7 +149,9 @@ namespace Adam.JSGenerator.Tests
         public void BinaryOperationExpressionSupportsBitwiseOr()
         {
             var b = A.BitwiseOrWith(B);
+            Assert.AreEqual("a|b;", b.ToString());
 
+            b = A | B;
             Assert.AreEqual("a|b;", b.ToString());
         }
 
@@ -133,7 +159,9 @@ namespace Adam.JSGenerator.Tests
         public void BinaryOperationExpressionSupportsBitwiseOrAndAssign()
         {
             var b = A.BitwiseOrWith(B).AndAssign();
+            Assert.AreEqual("a|=b;", b.ToString());
 
+            b = (A | B).AndAssign();
             Assert.AreEqual("a|=b;", b.ToString());
         }
 
@@ -141,7 +169,9 @@ namespace Adam.JSGenerator.Tests
         public void BinaryOperationExpressionSupportsBitwiseXor()
         {
             var b = A.BitwiseXorWith(B);
+            Assert.AreEqual("a^b;", b.ToString());
 
+            b = A ^ B;
             Assert.AreEqual("a^b;", b.ToString());
         }
 
@@ -149,7 +179,9 @@ namespace Adam.JSGenerator.Tests
         public void BinaryOperationExpressionSupportsBitwiseXorAndAssign()
         {
             var b = A.BitwiseXorWith(B).AndAssign();
+            Assert.AreEqual("a^=b;", b.ToString());
 
+            b = (A ^ B).AndAssign();
             Assert.AreEqual("a^=b;", b.ToString());
         }
 
@@ -221,7 +253,9 @@ namespace Adam.JSGenerator.Tests
         public void BinaryOperationExpressionSupportsGreaterThan()
         {
             var b = A.IsGreaterThan(B);
+            Assert.AreEqual("a>b;", b.ToString());
 
+            b = A > B;
             Assert.AreEqual("a>b;", b.ToString());
         }
 
@@ -229,7 +263,9 @@ namespace Adam.JSGenerator.Tests
         public void BinaryOperationExpressionSupportsGreaterThanOrEqualTo()
         {
             var b = A.IsGreaterThanOrEqualTo(B);
+            Assert.AreEqual("a>=b;", b.ToString());
 
+            b = A >= B;
             Assert.AreEqual("a>=b;", b.ToString());
         }
 
@@ -237,7 +273,9 @@ namespace Adam.JSGenerator.Tests
         public void BinaryOperationExpressionSupportsLessThan()
         {
             var b = A.IsLessThan(B);
+            Assert.AreEqual("a<b;", b.ToString());
 
+            b = A < B;
             Assert.AreEqual("a<b;", b.ToString());
         }
 
@@ -245,7 +283,9 @@ namespace Adam.JSGenerator.Tests
         public void BinaryOperationExpressionSupportsLessThanOrEqualTo()
         {
             var b = A.IsLessThanOrEqualTo(B);
+            Assert.AreEqual("a<=b;", b.ToString());
 
+            b = A <= B;
             Assert.AreEqual("a<=b;", b.ToString());
         }
 

--- a/Adam.JSGenerator.Tests/UnaryOperationExpressionTests.cs
+++ b/Adam.JSGenerator.Tests/UnaryOperationExpressionTests.cs
@@ -11,31 +11,22 @@ namespace Adam.JSGenerator.Tests
         {
             var a = JS.Id("a");
 
-            var expression1 = a.Number();
-            var expression2 = a.Negative();
-            var expression3 = a.BitwiseNot();
-            var expression4 = a.LogicalNot();
-            var expression5 = a.PreIncrement();
-            var expression6 = a.PostIncrement();
-            var expression7 = a.PreDecrement();
-            var expression8 = a.PostDecrement();
-            var expression9 = a.New();
-            var expression10 = a.TypeOf();
-            var expression11 = a.Delete();
-            var expression12 = a.Group();
-
-            Assert.AreEqual("+a;", expression1.ToString());
-            Assert.AreEqual("-a;", expression2.ToString());
-            Assert.AreEqual("~a;", expression3.ToString());
-            Assert.AreEqual("!a;", expression4.ToString());
-            Assert.AreEqual("++a;", expression5.ToString());
-            Assert.AreEqual("a++;", expression6.ToString());
-            Assert.AreEqual("--a;", expression7.ToString());
-            Assert.AreEqual("a--;", expression8.ToString());
-            Assert.AreEqual("new a();", expression9.ToString());
-            Assert.AreEqual("typeof a;", expression10.ToString());
-            Assert.AreEqual("delete a;", expression11.ToString());
-            Assert.AreEqual("(a);", expression12.ToString());
+            Assert.AreEqual("+a;", a.Number().ToString());
+            Assert.AreEqual("+a;", (+a).ToString());
+            Assert.AreEqual("-a;", a.Negative().ToString());
+            Assert.AreEqual("-a;", (-a).ToString());
+            Assert.AreEqual("~a;", a.BitwiseNot().ToString());
+            Assert.AreEqual("~a;", (~a).ToString());
+            Assert.AreEqual("!a;", a.LogicalNot().ToString());
+            Assert.AreEqual("!a;", (!a).ToString());
+            Assert.AreEqual("++a;", a.PreIncrement().ToString());
+            Assert.AreEqual("a++;", a.PostIncrement().ToString());
+            Assert.AreEqual("--a;", a.PreDecrement().ToString());
+            Assert.AreEqual("a--;", a.PostDecrement().ToString());
+            Assert.AreEqual("new a();", a.New().ToString());
+            Assert.AreEqual("typeof a;", a.TypeOf().ToString());
+            Assert.AreEqual("delete a;", a.Delete().ToString());
+            Assert.AreEqual("(a);", a.Group().ToString());
         }
 
         [TestMethod]

--- a/Adam.JSGenerator/Expression.cs
+++ b/Adam.JSGenerator/Expression.cs
@@ -194,5 +194,194 @@ namespace Adam.JSGenerator
 
 			return result;
 		}
-	}
+
+        #region Overloaded operators
+
+        #region Binary operation expressions
+
+        /// <summary>
+        /// Creates a new instance of <see cref="BinaryOperationExpression" /> that adds one expression to another.
+        /// </summary>
+        /// <param name="expression">The left side of the addition.</param>
+        /// <param name="operand">The right side of the addition.</param>
+        /// <returns>a new instance of <see cref="BinaryOperationExpression" />.</returns>
+        public static BinaryOperationExpression operator +(Expression expression, Expression operand)
+        {
+            return new BinaryOperationExpression(expression, operand, BinaryOperator.Add);
+        }
+
+        /// <summary>
+        /// Creates a new instance of <see cref="BinaryOperationExpression" /> that subtracts one expression from another.
+        /// </summary>
+        /// <param name="expression">The left side of the subtraction.</param>
+        /// <param name="operand">The right side of the subtraction.</param>
+        /// <returns>a new instance of <see cref="BinaryOperationExpression" />.</returns>
+        public static BinaryOperationExpression operator -(Expression expression, Expression operand)
+        {
+            return new BinaryOperationExpression(expression, operand, BinaryOperator.Subtract);
+        }
+
+        /// <summary>
+        /// Creates a new instance of <see cref="BinaryOperationExpression" /> that multiplies one expression by another.
+        /// </summary>
+        /// <param name="expression">The left side of the multiplication.</param>
+        /// <param name="operand">The right side of the multiplication.</param>
+        /// <returns>a new instance of <see cref="BinaryOperationExpression" />.</returns>
+        public static BinaryOperationExpression operator *(Expression expression, Expression operand)
+        {
+            return new BinaryOperationExpression(expression, operand, BinaryOperator.Multiply);
+        }
+
+        /// <summary>
+        /// Creates a new instance of <see cref="BinaryOperationExpression" /> that divides one expression by another.
+        /// </summary>
+        /// <param name="expression">The left side of the division.</param>
+        /// <param name="operand">The right side of the division.</param>
+        /// <returns>a new instance of <see cref="BinaryOperationExpression" />.</returns>
+        public static BinaryOperationExpression operator /(Expression expression, Expression operand)
+        {
+            return new BinaryOperationExpression(expression, operand, BinaryOperator.Divide);
+        }
+
+        /// <summary>
+        /// Creates a new instance of <see cref="BinaryOperationExpression" /> that computes the remainder of a division.
+        /// </summary>
+        /// <param name="expression">The left side of the remainder operation.</param>
+        /// <param name="operand">The right side of the remainder operation.</param>
+        /// <returns>a new instance of <see cref="BinaryOperationExpression" />.</returns>
+        public static BinaryOperationExpression operator %(Expression expression, Expression operand)
+        {
+            return new BinaryOperationExpression(expression, operand, BinaryOperator.Remain);
+        }
+
+        /// <summary>
+        /// Creates a new instance of <see cref="BinaryOperationExpression" /> that performs a bitwise and operation.
+        /// </summary>
+        /// <param name="expression">The left side of the bitwise and operation.</param>
+        /// <param name="operand">The right side of the bitwise and operation.</param>
+        /// <returns>a new instance of <see cref="BinaryOperationExpression" />.</returns>
+        public static BinaryOperationExpression operator &(Expression expression, Expression operand)
+        {
+            return new BinaryOperationExpression(expression, operand, BinaryOperator.BitwiseAnd);
+        }
+
+        /// <summary>
+        /// Creates a new instance of <see cref="BinaryOperationExpression" /> that performs a bitwise or operation.
+        /// </summary>
+        /// <param name="expression">The left side of the bitwise or operation.</param>
+        /// <param name="operand">The right side of the bitwise or operation.</param>
+        /// <returns>a new instance of <see cref="BinaryOperationExpression" />.</returns>
+        public static BinaryOperationExpression operator |(Expression expression, Expression operand)
+        {
+            return new BinaryOperationExpression(expression, operand, BinaryOperator.BitwiseOr);
+        }
+
+        /// <summary>
+        /// Creates a new instance of <see cref="BinaryOperationExpression" /> that performs a bitwise exclusive or operation.
+        /// </summary>
+        /// <param name="expression">The left side of the bitwise exclusive or operation.</param>
+        /// <param name="operand">The right side of the bitwise exclusive or operation.</param>
+        /// <returns>a new instance of <see cref="BinaryOperationExpression" />.</returns>
+        public static BinaryOperationExpression operator ^(Expression expression, Expression operand)
+        {
+            return new BinaryOperationExpression(expression, operand, BinaryOperator.BitwiseXor);
+        }
+        
+        /// <summary>
+        /// Creates a new instance of <see cref="BinaryOperationExpression" /> that performs a greater-than comparison.
+        /// </summary>
+        /// <param name="expression">The left side of the greater-than comparison.</param>
+        /// <param name="operand">The right side of the greater-than comparison.</param>
+        /// <returns>a new instance of <see cref="BinaryOperationExpression" />.</returns>
+        public static BinaryOperationExpression operator >(Expression expression, Expression operand)
+        {
+            return new BinaryOperationExpression(expression, operand, BinaryOperator.GreaterThan);
+        }
+
+        /// <summary>
+        /// Creates a new instance of <see cref="BinaryOperationExpression" /> that performs a greater-than-or-equal comparison.
+        /// </summary>
+        /// <param name="expression">The left side of the comparison.</param>
+        /// <param name="operand">The right side of the comparison.</param>
+        /// <returns>a new instance of <see cref="BinaryOperationExpression" />.</returns>
+        public static BinaryOperationExpression operator >=(Expression expression, Expression operand)
+        {
+            return new BinaryOperationExpression(expression, operand, BinaryOperator.GreaterThanOrEqualTo);
+        }
+
+        /// <summary>
+        /// Creates a new instance of <see cref="BinaryOperationExpression" /> that performs a less-than comparison.
+        /// </summary>
+        /// <param name="expression">The left side of the less-than comparison.</param>
+        /// <param name="operand">The right side of the less-than comparison.</param>
+        /// <returns>a new instance of <see cref="BinaryOperationExpression" />.</returns>
+        public static BinaryOperationExpression operator <(Expression expression, Expression operand)
+	    {
+            return new BinaryOperationExpression(expression, operand, BinaryOperator.LessThan);
+        }
+
+        /// <summary>
+        /// Creates a new instance of <see cref="BinaryOperationExpression" /> that performs a less-than-or-equal comparison.
+        /// </summary>
+        /// <param name="expression">The left side of the less-than comparison.</param>
+        /// <param name="operand">The right side of the less-than comparison.</param>
+        /// <returns>a new instance of <see cref="BinaryOperationExpression" />.</returns>
+        public static BinaryOperationExpression operator <=(Expression expression, Expression operand)
+	    {
+	        return new BinaryOperationExpression(expression, operand, BinaryOperator.LessThanOrEqualTo);
+	    }
+        
+        #endregion
+
+        #region Unary operation expressions
+
+        /// <summary>
+        /// Creates a new instance of <see cref="UnaryOperationExpression" /> that converts an expression to a number.
+        /// </summary>
+        /// <param name="expression">The expression to convert to a number.</param>
+        /// <returns>a new instance of <see cref="UnaryOperationExpression" /></returns>
+        /// <remarks>
+        /// Even though some sources state that the unary + operator is close to a no-op, the standard ECMA-262 clearly states its
+        /// purpose on p.72: to convert an expression to a number. If the expression cannot be converted, NaN is returned.
+        /// </remarks>
+        public static UnaryOperationExpression operator +(Expression expression)
+        {
+            return new UnaryOperationExpression(expression, UnaryOperator.Number);
+        }
+
+        /// <summary>
+        /// Creates a new instance of <see cref="UnaryOperationExpression" /> that negates the specified expression.
+        /// </summary>
+        /// <param name="expression">The expression to negate.</param>
+        /// <returns>a new instance of <see cref="UnaryOperationExpression" /></returns>
+        public static UnaryOperationExpression operator -(Expression expression)
+        {
+            return new UnaryOperationExpression(expression, UnaryOperator.Negative);
+        }
+
+        /// <summary>
+        /// Creates a new instance of <see cref="UnaryOperationExpression" /> that performs a bitwise not operation.
+        /// </summary>
+        /// <param name="expression">The expression on which to perform a bitwise not operation.</param>
+        /// <returns>a new instance of <see cref="UnaryOperationExpression" /></returns>
+        public static UnaryOperationExpression operator ~(Expression expression)
+        {
+            return new UnaryOperationExpression(expression, UnaryOperator.BitwiseNot);
+        }
+
+        /// <summary>
+        /// Creates a new instance of <see cref="UnaryOperationExpression" /> that performs a logical not operation.
+        /// </summary>
+        /// <param name="expression">The expression on which to perform a logical not operation.</param>
+        /// <returns>a new instance of <see cref="UnaryOperationExpression" /></returns>
+        public static UnaryOperationExpression operator !(Expression expression)
+	    {
+	        return new UnaryOperationExpression(expression, UnaryOperator.LogicalNot);
+	    }
+
+	    #endregion
+
+        #endregion
+
+    }
 }


### PR DESCRIPTION
Hi!
I wrote here some features related to use of overloaded operators with Expression instances.
For example: instead of writing `ex1.IsGreaterThanOrEqualTo(ex2)`, I can write `ex1 >= ex2`, and it returns a `BinaryOperationExpression`, like a first one.
Tests were exposed to assert overloaded operators behaviour.

Overloaded binary operators:  `+ - * / % & | ^ > < >= <=`
Overloaded unary operators:  `+ - ~ !`

P.S.: Hope there is no architectural decisions depending on to not overload operators behaviour.
